### PR TITLE
#142802303 pad ascii fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+      "lodash": "^4.17.4"
   },
   "devDependencies": {
     "mocha": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-      "lodash": "^4.17.4"
+      "lodash.padend": "^4.6.1"
   },
   "devDependencies": {
     "mocha": "^3.1.2",

--- a/src/DecoderRing.coffee
+++ b/src/DecoderRing.coffee
@@ -17,7 +17,7 @@ class DecoderRing
 
     return obj
 
-  encode: (obj, spec, checkMissingFields = false, noAssert = false) ->
+  encode: (obj, spec, checkMissingFields = false, noAssert = false, padding = null) ->
     size = spec.length ? @fieldEncoder.findSpecBufferSize(spec)
     buffer = Buffer.alloc(size)
 
@@ -37,7 +37,7 @@ class DecoderRing
         currentVal = bitFieldAccumulator["#{fieldSpec.start}"] || 0
         bitFieldAccumulator["#{fieldSpec.start}"] = currentVal + val
       else
-        buffer = encodeFun(buffer, obj, fieldSpec, noAssert)
+        buffer = encodeFun(buffer, obj, fieldSpec, noAssert, padding)
 
     # encode all the bit fields that we accumulated
     for r in Object.keys(bitFieldAccumulator)

--- a/src/FieldEncoder.coffee
+++ b/src/FieldEncoder.coffee
@@ -1,4 +1,4 @@
-_ = require('lodash')
+padEnd = require('lodash.padend')
 
 class FieldEncoder
   findSpecBufferSize: (spec) ->
@@ -27,7 +27,7 @@ class FieldEncoder
       val = fieldSpec.default
 
     if padding?
-      val = @_pad(val, fieldSpec.length, padding.padCharacter)
+      val = padEnd(val, fieldSpec.length, padding.padCharacter)
 
     if val?
       switch fieldSpec.type
@@ -58,7 +58,7 @@ class FieldEncoder
       val = fieldSpec.default
 
     if padding?
-      val = @_pad(val, fieldSpec.length, padding.padCharacter)
+      val = padEnd(val, fieldSpec.length, padding.padCharacter)
 
     if val?
       switch fieldSpec.type
@@ -81,7 +81,5 @@ class FieldEncoder
         #TODO error case
 
     return buffer
-
-  _pad: (val, length, character) -> _.padEnd(val, length, character)
 
 module.exports = FieldEncoder

--- a/src/FieldEncoder.coffee
+++ b/src/FieldEncoder.coffee
@@ -1,3 +1,5 @@
+_ = require('lodash')
+
 class FieldEncoder
   findSpecBufferSize: (spec) ->
     sizes = []
@@ -18,11 +20,14 @@ class FieldEncoder
     return field.start + length
 
 
-  encodeFieldBE: (buffer, obj, fieldSpec, noAssert = false) ->
+  encodeFieldBE: (buffer, obj, fieldSpec, noAssert = false, padding = null) ->
     val = obj[fieldSpec.name]
 
     if !val? and fieldSpec.default?
       val = fieldSpec.default
+
+    if padding?
+      val = @_pad(val, fieldSpec.length, padding.padCharacter)
 
     if val?
       switch fieldSpec.type
@@ -46,11 +51,14 @@ class FieldEncoder
 
     return buffer
 
-  encodeFieldLE: (buffer, obj, fieldSpec, noAssert = false) ->
+  encodeFieldLE: (buffer, obj, fieldSpec, noAssert = false, padding = null) ->
     val = obj[fieldSpec.name]
 
     if !val? and fieldSpec.default?
       val = fieldSpec.default
+
+    if padding?
+      val = @_pad(val, fieldSpec.length, padding.padCharacter)
 
     if val?
       switch fieldSpec.type
@@ -73,5 +81,7 @@ class FieldEncoder
         #TODO error case
 
     return buffer
+
+  _pad: (val, length, character) -> _.padEnd(val, length, character)
 
 module.exports = FieldEncoder

--- a/test/DecoderRingUnitTest.coffee
+++ b/test/DecoderRingUnitTest.coffee
@@ -153,4 +153,40 @@ describe "DecoderRing unit test", ->
 
       @subject.encode(field1: 11, spec)
 
+    it "passes padding args to BE field encoder", ->
+      spec =
+        bigEndian: true
+        length: 10
+        fields: [
+          { name: "field1", start: 0, type: 'ascii', length: 10}
+        ]
 
+      inputObj =
+        field1: "Deckard"
+
+      padObj =
+        padCharacter: ' '
+
+      @fieldEncoderMock.expects('encodeFieldBE').withArgs(sinon.match.instanceOf(Buffer),
+      sinon.match.object, sinon.match.object, false, padObj)
+
+      @subject.encode(inputObj, spec, false, false, padObj)
+
+    it "passes padding args to LE field encoder", ->
+      spec =
+        bigEndian: false
+        length: 10
+        fields: [
+          { name: "field1", start: 0, type: 'ascii', length: 10}
+        ]
+
+      inputObj =
+        field1: "Deckard"
+
+      padObj =
+        padCharacter: ' '
+
+      @fieldEncoderMock.expects('encodeFieldLE').withArgs(sinon.match.instanceOf(Buffer),
+      sinon.match.object, sinon.match.object, false, padObj)
+
+      @subject.encode(inputObj, spec, false, false, padObj)

--- a/test/FieldEncoderUnitTest.coffee
+++ b/test/FieldEncoderUnitTest.coffee
@@ -137,6 +137,20 @@ describe "FieldEncoder unit test", ->
       result = @subject.encodeFieldBE(outBuffer, obj, fieldSpec)
       expect(result).to.deep.equal(expectedBuffer)
 
+    it "encodes an ascii field with padding", ->
+      expectedBuffer = Buffer.alloc(15)
+      expectedBuffer.write("ascii text     ", 0, 15, 'ascii')
+
+      outBuffer = Buffer.alloc(15)
+
+      obj = {field7: "ascii text"}
+      fieldSpec = {name: "field7", start: 0, type: 'ascii', length: 15}
+      padObj = { padCharacter: ' '  }
+
+      result = @subject.encodeFieldBE(outBuffer, obj, fieldSpec, false, padObj)
+      expect(result).to.deep.equal(expectedBuffer)
+
+
     it "encodes an utf8 field", ->
       expectedBuffer = Buffer.alloc(15)
       expectedBuffer.write("utf8 text", 1, 9, 'utf8')
@@ -314,6 +328,19 @@ describe "FieldEncoder unit test", ->
       result = @subject.encodeFieldLE(outBuffer, obj, fieldSpec)
       expect(result).to.deep.equal(expectedBuffer)
 
+    it "encodes an ascii field with padding", ->
+      expectedBuffer = Buffer.alloc(15)
+      expectedBuffer.write("ascii text     ", 0, 15, 'ascii')
+
+      outBuffer = Buffer.alloc(15)
+
+      obj = {field7: "ascii text"}
+      fieldSpec = {name: "field7", start: 0, type: 'ascii', length: 15}
+      padObj = { padCharacter: ' '  }
+
+      result = @subject.encodeFieldLE(outBuffer, obj, fieldSpec, false, padObj)
+      expect(result).to.deep.equal(expectedBuffer)
+
     it "encodes an utf8 field", ->
       expectedBuffer = Buffer.alloc(15)
       expectedBuffer.write("utf8 text", 1, 9, 'utf8')
@@ -437,7 +464,7 @@ describe "FieldEncoder unit test", ->
 
     it "works for buffers", ->
       field = {name: "field1", start: 2,  type: 'buffer', length: 3 }
-        
+
       result = @subject.findFieldLength(field)
       expect(result).to.equal(5)
 


### PR DESCRIPTION
Please see [issue #142802303](https://www.pivotaltracker.com/n/projects/1997123).

Allow a padding option to be passed in so that ascii fields can be passing with something other than nulls. There is some definite refactorability here: it would nicer to pass a config object that contains the various argument. For the time being I will save that for later considering that this would result in more changes necessary for consuming apps (us?).